### PR TITLE
Use correct dates in report metadata.txt

### DIFF
--- a/TNAtoolAPI-Webapp/src/main/webapp/resources/js/JSMethods.js
+++ b/TNAtoolAPI-Webapp/src/main/webapp/resources/js/JSMethods.js
@@ -359,7 +359,10 @@ String.prototype.strip = function () {
  * gathers the metadata of the tabular report in a text file to be exported.
  */
 function getMetadata() {
-	
+	// Get selected dates
+	var dates = $('#datepicker').multiDatesPicker('getDates');
+	var keyName = setDates(dates.join(","));
+
 	/*
 	 * Appending metadata
 	 */


### PR DESCRIPTION
Get the current state of the date selector widget to use in the metadata.txt file.

Resolves #124